### PR TITLE
NoTicket - move jest to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/BrandwatchLtd/stylelint-config-axiom#readme",
   "devDependencies": {
-    "semantic-release": "^7.0.2"
+    "semantic-release": "^7.0.2",
+    "jest": "^20.0.4"
   },
   "dependencies": {
-    "jest": "^20.0.4",
     "stylelint": "^7.9.0",
     "stylelint-order": "^0.6.0"
   },


### PR DESCRIPTION
I had to move jest to` devDependency` since that package is part of frontend repo now It started to include that jest version and make a clash with our functional tests.  